### PR TITLE
Modification pour permettre la compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.31)
 
 project(FreeMajor VERSION "1.0" LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.25.1)
 
 project(FreeMajor VERSION "1.0" LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/sources/utility/misc.h
+++ b/sources/utility/misc.h
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
+// Modifié par Julien Taverna 2026 - pour compilation
 
 #pragma once
 #include <string>
@@ -10,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <cstdint>
 #include <sys/types.h>
 
 // stream RAII


### PR DESCRIPTION
Ajout de "#include <cstdint>" dans le fichier misc.h pour permettre la compilation.
Changement de version minimum pour la version 3.31 de Cmake.